### PR TITLE
fix: apontar SonarQube para servidor do professor

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=danieloda_devops
-sonar.organization=danieloda
+sonar.projectName=MarmitaTech Pro
 sonar.sources=.
 sonar.exclusions=node_modules/**,docs/**,coverage/**,**/*.test.js
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
Atualiza sonar-project.properties para apontar para o servidor SonarQube da disciplina.