### PR TITLE
feat: pipeline dev→staging→main com Docker Hub release e Trivy→Sonar (#20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+APP_CONTAINER_NAME=danielodadevops
+APP_PORT=8081
+APP_IMAGE=danielodaceub/marmitatech-pro:latest
+DB_HOST=dbcentral
+DB_USER=root
+DB_PASS=password
+DB_NAME=danielodadevops

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_CONTAINER_NAME=danielodadevops
 APP_PORT=8081
-APP_IMAGE=danielodaceub/marmitatech-pro:latest
-DB_HOST=dbcentral
+APP_IMAGE=danielodaceub/devops:latest
+DB_HOST=54.89.88.5 #dbcentral
 DB_USER=root
 DB_PASS=password
 DB_NAME=danielodadevops

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,42 +1,41 @@
-name: CI - Build, Lint e SonarQube
+name: CI/CD - Build, Lint, Sonar, Release & Trivy
 
 on:
   push:
-    branches:
-      - "dev"
-      - "main"
+    branches: ["dev", "staging", "main"]
   pull_request:
-    branches:
-      - "dev"
-      - "main"
+    branches: ["dev", "staging", "main"]
 
 jobs:
-  job_build:
-    name: Estágio de Build
+  # ==========================================================================
+  # CI — roda em todas as branches/PRs
+  # ==========================================================================
+  build:
+    name: Build (sintaxe + deps)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
       - run: npm ci
       - run: npm run build
 
-  job_lint:
-    name: Estágio de Lint
-    needs: job_build
+  lint:
+    name: Lint (ESLint)
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
       - run: npm ci
       - run: npm run lint
 
-  job_sonar:
-    name: Estágio de Inspeção
-    needs: job_lint
+  test_sonar:
+    name: Test + SonarQube
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,10 +43,95 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
       - run: npm ci
       - run: npm test
-      - uses: sonarsource/sonarqube-scan-action@master
+
+      - name: SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.branch.name=${{ github.ref_name }}
+
+  # ==========================================================================
+  # RELEASE — só em push na branch staging
+  # ==========================================================================
+  release_docker:
+    name: Release - Build & Push Docker Hub
+    needs: test_sonar
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+      image_latest: ${{ steps.meta.outputs.image_latest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login no Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Definir tags da imagem
+        id: meta
+        run: |
+          IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/marmitatech-pro"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "image_tag=$IMAGE:$SHA_SHORT" >> "$GITHUB_OUTPUT"
+          echo "image_latest=$IMAGE:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Build & Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image_tag }}
+            ${{ steps.meta.outputs.image_latest }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ==========================================================================
+  # TRIVY → SONAR EXTERNAL ISSUES — só em push na branch staging
+  # ==========================================================================
+  trivy_sonar:
+    name: Trivy Scan → Sonar External Issues
+    needs: release_docker
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Trivy scan (template Sonar)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ needs.release_docker.outputs.image_tag }}
+          format: template
+          template: "@/contrib/sonarqube.tpl"
+          output: trivy-report.json
+          severity: CRITICAL,HIGH,MEDIUM
+          exit-code: "0"
+
+      - name: Exibir relatório Trivy (debug)
+        run: |
+          echo "===== TRIVY REPORT ====="
+          cat trivy-report.json || echo "(vazio)"
+
+      - name: SonarQube Scan (External Issues)
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.branch.name=${{ github.ref_name }}
+            -Dsonar.externalIssuesReportPaths=trivy-report.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Definir tags da imagem
         id: meta
         run: |
-          IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/marmitatech-pro"
+          IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/devops"
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
           echo "image_tag=$IMAGE:$SHA_SHORT" >> "$GITHUB_OUTPUT"
           echo "image_latest=$IMAGE:latest" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 node_modules/
 CLAUDE.md
+.env
+coverage/
+*.log
+.DS_Store
+trivy-report.json

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,32 @@
+services:
+  db:
+    image: mysql:8.0
+    container_name: marmitatech-db-dev
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build: .
+    container_name: marmitatech-app-dev
+    ports:
+      - "3000:3000"
+    environment:
+      DB_HOST: db
+      DB_USER: ${DB_USER}
+      DB_PASS: ${DB_PASS}
+      DB_NAME: ${DB_NAME}
+    depends_on:
+      db:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,20 @@
 services:
-  db:
-    image: mysql:8.0
-    container_name: marmitatech-db
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: marmitadb
-      MYSQL_USER: user
-      MYSQL_PASSWORD: password
-    ports:
-      - "3306:3306"
-    volumes:
-      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-
   app:
-    build: .
-    container_name: marmitatech-app
+    image: ${APP_IMAGE}
+    container_name: ${APP_CONTAINER_NAME}
+    restart: unless-stopped
     ports:
-      - "3000:3000"
-    environment:
-      DB_HOST: db
-      DB_USER: user
-      DB_PASS: password
-      DB_NAME: marmitadb
-    depends_on:
-      db:
-        condition: service_healthy
+      - "${APP_PORT}:3000"
+    env_file: .env
+    networks:
+      - rede_alunos
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+networks:
+  rede_alunos:
+    external: true

--- a/scripts/migrate.sql
+++ b/scripts/migrate.sql
@@ -1,0 +1,36 @@
+-- ==========================================================================
+-- Migration idempotente para o banco compartilhado `dbcentral` na EC2.
+-- Executar uma vez via:
+--   sudo docker exec -i dbcentral mysql -uroot -ppassword < scripts/migrate.sql
+-- ==========================================================================
+
+CREATE DATABASE IF NOT EXISTS danielodadevops
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+USE danielodadevops;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    category VARCHAR(50)
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    customer_name VARCHAR(100),
+    status VARCHAR(20) DEFAULT 'Aberto'
+);
+
+-- Usuário admin padrão (senha: admin123, hash bcrypt). Só insere se ainda não existir.
+INSERT IGNORE INTO users (username, password)
+VALUES ('admin', '$2b$10$nV4nqvT7Nr2BeRk/VOzlBe3LZmpDQJZ7Mljq5Fx5ZGlh0WA7uayWi');
+
+INSERT IGNORE INTO items (id, name, category) VALUES
+  (1, 'Arroz Branco', 'Base'),
+  (2, 'Feijão Preto', 'Grão');


### PR DESCRIPTION
## Resumo
Implementa o fluxo profissional de release seguindo materiais da aula de **Engenharia de Release e Segurança**.

Closes #20

## Mudanças

### CI/CD (`.github/workflows/ci.yml`)
- **Todas as branches**: build → lint → test+sonar
- **Push staging**: `release_docker` (build & push Docker Hub) → `trivy_sonar` (External Issues)
- Tags da imagem: `:latest` e `:<sha-7>`

### Compose
- `docker-compose.yml` — produção EC2, parametrizado via env vars, rede externa `rede_alunos`, healthcheck
- `docker-compose.dev.yml` — dev local com MySQL próprio (preserva fluxo antigo)

### Banco
- `scripts/migrate.sql` — DDL idempotente para rodar 1x no `dbcentral` da EC2

### Config
- `.env.example` — template com `APP_PORT=8081`, `APP_CONTAINER_NAME=danielodadevops`, `DB_NAME=danielodadevops`
- `.gitignore` — adiciona `.env`, `coverage/`, `trivy-report.json`

## Pré-requisitos para o pipeline rodar
- [x] Secret `DOCKERHUB_USERNAME` configurado
- [x] Secret `DOCKERHUB_TOKEN` configurado
- [x] Secrets `SONAR_TOKEN` e `SONAR_HOST_URL` (já existiam)
- [ ] Repositório `danielodaceub/marmitatech-pro` criado no Docker Hub (Public)
- [ ] Branch `staging` criada (pós-merge)
- [ ] Secrets `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY` para futuro job de deploy SSH

## Como testar localmente
```bash
cp .env.example .env
docker compose -f docker-compose.dev.yml up --build
# acessar http://localhost:3000
```

## Fluxo pós-merge
1. Merge para `dev` → pipeline básico (build/lint/sonar)
2. Criar branch `staging` a partir de `main`
3. PR `dev` → `staging` → pipeline completo (build/lint/sonar + release + trivy→sonar)
4. PR `staging` → `main` → release oficial

## Pendências futuras (issues separadas)
- Job `deploy_ec2` (SSH + pull + restart) quando EC2_* secrets estiverem prontos
- Rotação da chave SSH EC2 anterior (comprometida)