### PR TITLE
feat: validação de input e prevenção de SQL Injection (#5)

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,21 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
+// ---------- Validação de Input (Issue #05) ----------
+// Rejeita dados inválidos antes de tocar no banco. Retorna lista de erros.
+function validarItem({ name, price }) {
+    const erros = [];
+    if (!name || String(name).trim() === '') {
+        erros.push('O nome da marmita é obrigatório.');
+    }
+    const preco = Number(price);
+    if (price === undefined || price === null || String(price).trim() === '' ||
+        Number.isNaN(preco) || preco <= 0) {
+        erros.push('O preço deve ser um número positivo.');
+    }
+    return erros;
+}
+
 app.get('/', (req, res) => res.render('login'));
 
 app.post('/login', async (req, res) => {
@@ -51,6 +66,27 @@ app.post('/login', async (req, res) => {
         }
     } catch (err) {
         res.status(500).send("Erro no banco.");
+    }
+});
+
+// ---------- Cadastro de Item/Marmita (Issues #05, #06) ----------
+// Validação de input + Prepared Statement (parâmetros ?) contra SQL Injection.
+app.post('/add-item', async (req, res) => {
+    const { name, category, price } = req.body;
+    const erros = validarItem({ name, price });
+    if (erros.length > 0) {
+        return res.status(400).send(`<h1>Erro 400 - Dados inválidos</h1><ul>${
+            erros.map(e => `<li>${e}</li>`).join('')
+        }</ul><a href="/dashboard">Voltar</a>`);
+    }
+    try {
+        await pool.query(
+            'INSERT INTO items (name, category, price) VALUES (?, ?, ?)',
+            [String(name).trim(), String(category || '').trim(), Number(price)]
+        );
+        res.redirect('/dashboard');
+    } catch (err) {
+        res.status(500).send('Erro no banco.');
     }
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -83,6 +83,45 @@ describe('POST /login', () => {
     });
 });
 
+describe('POST /add-item (validação - Issue #05)', () => {
+    it('should create item and redirect on valid data', async () => {
+        mockQuery.mockResolvedValue([{ insertId: 1 }]);
+        const res = await request(app)
+            .post('/add-item')
+            .send('name=Marmita Fitness&category=Fitness&price=22.90');
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toBe('/dashboard');
+        expect(mockQuery).toHaveBeenCalledWith(
+            'INSERT INTO items (name, category, price) VALUES (?, ?, ?)',
+            ['Marmita Fitness', 'Fitness', 22.9]
+        );
+    });
+
+    it('should return 400 when name is empty', async () => {
+        const res = await request(app)
+            .post('/add-item')
+            .send('name=&category=Fitness&price=22.90');
+        expect(res.status).toBe(400);
+        expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when price is negative', async () => {
+        const res = await request(app)
+            .post('/add-item')
+            .send('name=Marmita&price=-5');
+        expect(res.status).toBe(400);
+        expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when price is not a number', async () => {
+        const res = await request(app)
+            .post('/add-item')
+            .send('name=Marmita&price=abc');
+        expect(res.status).toBe(400);
+        expect(mockQuery).not.toHaveBeenCalled();
+    });
+});
+
 describe('GET /dashboard', () => {
     it('should render dashboard with items and orders', async () => {
         mockQuery

--- a/init.sql
+++ b/init.sql
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE IF NOT EXISTS items (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
-    category VARCHAR(50)
+    category VARCHAR(50),
+    price DECIMAL(10,2) NOT NULL DEFAULT 0.00
 );
 
 CREATE TABLE IF NOT EXISTS orders (
@@ -17,4 +18,7 @@ CREATE TABLE IF NOT EXISTS orders (
 );
 
 INSERT INTO users (username, password) VALUES ('admin', '$2b$10$nV4nqvT7Nr2BeRk/VOzlBe3LZmpDQJZ7Mljq5Fx5ZGlh0WA7uayWi');
-INSERT INTO items (name, category) VALUES ('Arroz Branco', 'Base'), ('Feijão Preto', 'Grão');
+INSERT INTO items (name, category, price) VALUES
+    ('Marmita Fitness Frango', 'Fitness', 22.90),
+    ('Marmita Tradicional', 'Tradicional', 18.50),
+    ('Marmita Vegana', 'Vegana', 24.00);

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -12,19 +12,20 @@
     <h1>Painel Administrativo - MarmitaTech</h1>
     <div class="grid">
         <div class="card">
-            <h3>Novo Item (Ingrediente)</h3>
+            <h3>Nova Marmita</h3>
             <form action="/add-item" method="POST">
-                <input type="text" name="name" placeholder="Nome (Ex: Batata Doce)" required><br><br>
-                <input type="text" name="category" placeholder="Categoria (Ex: Carboidrato)"><br><br>
-                <button type="submit">Cadastrar Item</button>
+                <input type="text" name="name" placeholder="Nome (Ex: Marmita Fitness)" required><br><br>
+                <input type="text" name="category" placeholder="Categoria (Ex: Fitness)"><br><br>
+                <input type="number" name="price" step="0.01" min="0.01" placeholder="Preço (Ex: 22.90)" required><br><br>
+                <button type="submit">Cadastrar Marmita</button>
             </form>
         </div>
 
         <div class="card">
-            <h3>Itens Cadastrados</h3>
+            <h3>Marmitas Cadastradas</h3>
             <ul>
                 <% items.forEach(item => { %>
-                    <li><%= item.name %> (<%= item.category %>)</li>
+                    <li><%= item.name %> (<%= item.category %>) — R$ <%= Number(item.price).toFixed(2) %></li>
                 <% }) %>
             </ul>
         </div>


### PR DESCRIPTION
## Issue #5 — Prevenção de SQL Injection e Validação de Input

### O que foi feito
- ✅ **Prepared Statements** (parâmetros `?`) em todas as queries — blindagem contra SQL Injection
- ✅ Função `validarItem()`: rejeita nome vazio e preço não-positivo/não-numérico
- ✅ Nova rota `POST /add-item` (que o dashboard referenciava mas não existia)
- ✅ Retorna **HTTP 400** para dados inválidos
- ✅ Coluna `price DECIMAL(10,2)` em `items` + seed de marmitas
- ✅ 4 testes novos (total 11, todos verdes)

### Critério de aceite
> O sistema rejeita inputs maliciosos e retorna erro 400 ✅

Closes #5