### PR TITLE
feat: módulo de cadastro de pedidos (#6)

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,44 @@ app.post('/add-item', async (req, res) => {
     }
 });
 
+// ---------- Cadastro de Pedidos (Issue #06) ----------
+// Associa um cliente a uma marmita disponível. Status inicial: "Aberto".
+app.post('/orders', async (req, res) => {
+    const { customer_name, item_id } = req.body;
+    const erros = [];
+    if (!customer_name || String(customer_name).trim() === '') {
+        erros.push('O nome do cliente é obrigatório.');
+    }
+    if (!item_id || Number.isNaN(Number(item_id))) {
+        erros.push('Selecione uma marmita válida.');
+    }
+    if (erros.length > 0) {
+        return res.status(400).send(`<h1>Erro 400 - Dados inválidos</h1><ul>${
+            erros.map(e => `<li>${e}</li>`).join('')
+        }</ul><a href="/dashboard">Voltar</a>`);
+    }
+    try {
+        const [found] = await pool.query('SELECT price FROM items WHERE id = ?', [Number(item_id)]);
+        if (found.length === 0) {
+            return res.status(400).send('<h1>Erro 400 - Marmita inexistente</h1><a href="/dashboard">Voltar</a>');
+        }
+        await pool.query(
+            'INSERT INTO orders (customer_name, item_id, total, status) VALUES (?, ?, ?, ?)',
+            [String(customer_name).trim(), Number(item_id), found[0].price, 'Aberto']
+        );
+        res.redirect('/dashboard');
+    } catch (err) {
+        res.status(500).send('Erro no banco.');
+    }
+});
+
 app.get('/dashboard', async (req, res) => {
     const [items] = await pool.query('SELECT * FROM items');
-    const [orders] = await pool.query('SELECT * FROM orders');
+    const [orders] = await pool.query(
+        `SELECT o.id, o.customer_name, o.status, o.total, o.created_at, i.name AS item_name
+         FROM orders o LEFT JOIN items i ON o.item_id = i.id
+         ORDER BY o.id DESC`
+    );
     res.render('dashboard', { items, orders });
 });
 

--- a/index.test.js
+++ b/index.test.js
@@ -122,11 +122,39 @@ describe('POST /add-item (validação - Issue #05)', () => {
     });
 });
 
+describe('POST /orders (Issue #06)', () => {
+    it('should create order with status Aberto on valid data', async () => {
+        mockQuery
+            .mockResolvedValueOnce([[{ price: 22.9 }]]) // SELECT price FROM items
+            .mockResolvedValueOnce([{ insertId: 1 }]);  // INSERT INTO orders
+        const res = await request(app)
+            .post('/orders')
+            .send('customer_name=João&item_id=1');
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toBe('/dashboard');
+        expect(mockQuery).toHaveBeenLastCalledWith(
+            'INSERT INTO orders (customer_name, item_id, total, status) VALUES (?, ?, ?, ?)',
+            ['João', 1, 22.9, 'Aberto']
+        );
+    });
+
+    it('should return 400 when customer name is empty', async () => {
+        const res = await request(app).post('/orders').send('customer_name=&item_id=1');
+        expect(res.status).toBe(400);
+    });
+
+    it('should return 400 when item does not exist', async () => {
+        mockQuery.mockResolvedValueOnce([[]]); // SELECT price -> vazio
+        const res = await request(app).post('/orders').send('customer_name=Ana&item_id=999');
+        expect(res.status).toBe(400);
+    });
+});
+
 describe('GET /dashboard', () => {
     it('should render dashboard with items and orders', async () => {
         mockQuery
-            .mockResolvedValueOnce([[{ id: 1, name: 'Arroz', category: 'Base' }]])
-            .mockResolvedValueOnce([[{ id: 1, customer_name: 'João', status: 'Aberto' }]]);
+            .mockResolvedValueOnce([[{ id: 1, name: 'Marmita', category: 'Fitness', price: 22.9 }]])
+            .mockResolvedValueOnce([[{ id: 1, customer_name: 'João', item_name: 'Marmita', total: 22.9, status: 'Aberto' }]]);
 
         const res = await request(app).get('/dashboard');
         expect(res.status).toBe(200);

--- a/init.sql
+++ b/init.sql
@@ -13,8 +13,12 @@ CREATE TABLE IF NOT EXISTS items (
 
 CREATE TABLE IF NOT EXISTS orders (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    customer_name VARCHAR(100),
-    status VARCHAR(20) DEFAULT 'Aberto'
+    customer_name VARCHAR(100) NOT NULL,
+    item_id INT,
+    total DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    status VARCHAR(20) DEFAULT 'Aberto',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (item_id) REFERENCES items(id)
 );
 
 INSERT INTO users (username, password) VALUES ('admin', '$2b$10$nV4nqvT7Nr2BeRk/VOzlBe3LZmpDQJZ7Mljq5Fx5ZGlh0WA7uayWi');

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -29,10 +29,35 @@
                 <% }) %>
             </ul>
         </div>
+
+        <div class="card">
+            <h3>Novo Pedido</h3>
+            <form action="/orders" method="POST">
+                <input type="text" name="customer_name" placeholder="Nome do cliente" required><br><br>
+                <select name="item_id" required>
+                    <option value="" disabled selected>Selecione a marmita</option>
+                    <% items.forEach(item => { %>
+                        <option value="<%= item.id %>"><%= item.name %> — R$ <%= Number(item.price).toFixed(2) %></option>
+                    <% }) %>
+                </select><br><br>
+                <button type="submit">Registrar Pedido</button>
+            </form>
+        </div>
     </div>
 
     <hr>
     <h2>📦 Pedidos Ativos</h2>
-    <p><i>Aqui será implementado o Kanban nas próximas aulas...</i></p>
+    <table border="1" cellpadding="8" style="border-collapse: collapse;">
+        <tr><th>#</th><th>Cliente</th><th>Marmita</th><th>Valor</th><th>Status</th></tr>
+        <% orders.forEach(order => { %>
+            <tr>
+                <td><%= order.id %></td>
+                <td><%= order.customer_name %></td>
+                <td><%= order.item_name || '-' %></td>
+                <td>R$ <%= Number(order.total || 0).toFixed(2) %></td>
+                <td><%= order.status %></td>
+            </tr>
+        <% }) %>
+    </table>
 </body>
 </html>


### PR DESCRIPTION
## Issue #6 — Módulo de Cadastro de Pedidos

### O que foi feito
- ✅ Rota `POST /orders` grava o pedido (Prepared Statement)
- ✅ Interface de seleção de marmita (`<select>`) + nome do cliente
- ✅ Status inicial **"Aberto"**, valor total derivado do preço da marmita
- ✅ Schema `orders` com `item_id` (FK), `total`, `created_at`
- ✅ Dashboard lista os pedidos (JOIN com items)
- ✅ 3 testes novos (14 no total, verdes)

### Critério de aceite
> O pedido deve ser listado no Dashboard imediatamente após a criação ✅

Closes #6