### PR TITLE
feat: painel Kanban da cozinha (#7)

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,30 @@ app.post('/orders', async (req, res) => {
     }
 });
 
+// ---------- Painel Kanban da Cozinha (Issue #07) ----------
+// Fluxo de produção: Aberto -> Cozinha -> Entrega -> Entregue.
+const FLUXO_STATUS = { 'Aberto': 'Cozinha', 'Cozinha': 'Entrega', 'Entrega': 'Entregue' };
+
+app.post('/orders/:id/advance', async (req, res) => {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+        return res.status(400).send('<h1>Erro 400 - ID inválido</h1>');
+    }
+    try {
+        const [rows] = await pool.query('SELECT status FROM orders WHERE id = ?', [id]);
+        if (rows.length === 0) {
+            return res.status(404).send('<h1>Erro 404 - Pedido não encontrado</h1>');
+        }
+        const proximo = FLUXO_STATUS[rows[0].status];
+        if (proximo) {
+            await pool.query('UPDATE orders SET status = ? WHERE id = ?', [proximo, id]);
+        }
+        res.redirect('/dashboard');
+    } catch (err) {
+        res.status(500).send('Erro no banco.');
+    }
+});
+
 app.get('/dashboard', async (req, res) => {
     const [items] = await pool.query('SELECT * FROM items');
     const [orders] = await pool.query(

--- a/index.test.js
+++ b/index.test.js
@@ -150,6 +150,33 @@ describe('POST /orders (Issue #06)', () => {
     });
 });
 
+describe('POST /orders/:id/advance (Kanban - Issue #07)', () => {
+    it('should advance status from Aberto to Cozinha', async () => {
+        mockQuery
+            .mockResolvedValueOnce([[{ status: 'Aberto' }]]) // SELECT status
+            .mockResolvedValueOnce([{ affectedRows: 1 }]);    // UPDATE
+        const res = await request(app).post('/orders/1/advance');
+        expect(res.status).toBe(302);
+        expect(mockQuery).toHaveBeenLastCalledWith(
+            'UPDATE orders SET status = ? WHERE id = ?',
+            ['Cozinha', 1]
+        );
+    });
+
+    it('should not update when order is already Entregue (terminal)', async () => {
+        mockQuery.mockResolvedValueOnce([[{ status: 'Entregue' }]]);
+        const res = await request(app).post('/orders/1/advance');
+        expect(res.status).toBe(302);
+        expect(mockQuery).toHaveBeenCalledTimes(1); // só o SELECT, sem UPDATE
+    });
+
+    it('should return 404 when order not found', async () => {
+        mockQuery.mockResolvedValueOnce([[]]);
+        const res = await request(app).post('/orders/999/advance');
+        expect(res.status).toBe(404);
+    });
+});
+
 describe('GET /dashboard', () => {
     it('should render dashboard with items and orders', async () => {
         mockQuery

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -4,8 +4,19 @@
     <title>MarmitaTech - Dashboard</title>
     <style>
         body { font-family: sans-serif; padding: 20px; }
-        .grid { display: flex; gap: 20px; }
+        .grid { display: flex; gap: 20px; flex-wrap: wrap; }
         .card { border: 1px solid #ccc; padding: 15px; border-radius: 8px; width: 300px; }
+        .kanban { display: flex; gap: 15px; flex-wrap: wrap; }
+        .kanban-col { flex: 1; min-width: 200px; background: #f4f4f7; border-radius: 8px; padding: 10px; }
+        .col-title { margin: 0 0 10px; padding: 6px; border-radius: 6px; color: #fff; text-align: center; font-size: 15px; }
+        .col-aberto { background: #6c757d; }
+        .col-cozinha { background: #e94560; }
+        .col-entrega { background: #f39c12; }
+        .col-entregue { background: #27ae60; }
+        .kanban-card { background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 10px; margin-bottom: 10px; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+        .kanban-card .meta { font-size: 13px; color: #555; margin: 5px 0; }
+        .btn-advance { background: #e94560; color: #fff; border: none; padding: 6px 10px; border-radius: 5px; cursor: pointer; width: 100%; }
+        .btn-advance:hover { background: #c81e3c; }
     </style>
 </head>
 <body>
@@ -46,18 +57,25 @@
     </div>
 
     <hr>
-    <h2>📦 Pedidos Ativos</h2>
-    <table border="1" cellpadding="8" style="border-collapse: collapse;">
-        <tr><th>#</th><th>Cliente</th><th>Marmita</th><th>Valor</th><th>Status</th></tr>
-        <% orders.forEach(order => { %>
-            <tr>
-                <td><%= order.id %></td>
-                <td><%= order.customer_name %></td>
-                <td><%= order.item_name || '-' %></td>
-                <td>R$ <%= Number(order.total || 0).toFixed(2) %></td>
-                <td><%= order.status %></td>
-            </tr>
+    <h2>🍱 Kanban da Cozinha</h2>
+    <% const COLUNAS = ['Aberto', 'Cozinha', 'Entrega', 'Entregue']; %>
+    <div class="kanban">
+        <% COLUNAS.forEach(coluna => { %>
+            <div class="kanban-col">
+                <h3 class="col-title col-<%= coluna.toLowerCase() %>"><%= coluna %></h3>
+                <% orders.filter(o => o.status === coluna).forEach(order => { %>
+                    <div class="kanban-card">
+                        <strong>#<%= order.id %> · <%= order.customer_name %></strong>
+                        <div class="meta"><%= order.item_name || '-' %> — R$ <%= Number(order.total || 0).toFixed(2) %></div>
+                        <% if (coluna !== 'Entregue') { %>
+                            <form action="/orders/<%= order.id %>/advance" method="POST">
+                                <button type="submit" class="btn-advance">Avançar →</button>
+                            </form>
+                        <% } %>
+                    </div>
+                <% }) %>
+            </div>
         <% }) %>
-    </table>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Issue #7 — Painel Kanban da Cozinha (Gestão de Status)

### O que foi feito
- ✅ Board com 4 colunas: **Aberto · Cozinha · Entrega · Entregue**
- ✅ Botão **"Avançar →"** em cada card avança o status
- ✅ Atualização via `UPDATE` (Prepared Statement) na rota `POST /orders/:id/advance`
- ✅ Status terminal (Entregue) não avança; pedido inexistente retorna 404
- ✅ 3 testes novos (17 no total, verdes)

### Critério de aceite
> O pedido muda de coluna visualmente ao clicar no botão de avanço ✅

Closes #7