### PR TITLE
feat: relatório de vendas (exportação CSV) (#8)

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,32 @@ app.post('/orders/:id/advance', async (req, res) => {
     }
 });
 
+// ---------- Relatório de Vendas em CSV (Issue #08) ----------
+// Exporta o histórico de pedidos para controle financeiro (abre no Excel).
+app.get('/admin/export', async (req, res) => {
+    try {
+        const [orders] = await pool.query(
+            `SELECT o.id, o.customer_name, i.name AS item_name, o.total, o.status, o.created_at
+             FROM orders o LEFT JOIN items i ON o.item_id = i.id
+             ORDER BY o.id`
+        );
+        const cabecalho = 'ID,Cliente,Marmita,Valor,Status,Data';
+        const linhas = orders.map(o => {
+            const data = o.created_at ? new Date(o.created_at).toISOString().slice(0, 10) : '';
+            const cliente = `"${String(o.customer_name || '').replace(/"/g, '""')}"`;
+            const marmita = `"${String(o.item_name || '').replace(/"/g, '""')}"`;
+            return [o.id, cliente, marmita, Number(o.total || 0).toFixed(2), o.status, data].join(',');
+        });
+        // BOM (\uFEFF) garante acentuação correta ao abrir no Excel.
+        const csv = '\uFEFF' + [cabecalho, ...linhas].join('\n');
+        res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+        res.setHeader('Content-Disposition', 'attachment; filename="relatorio-vendas.csv"');
+        res.send(csv);
+    } catch (err) {
+        res.status(500).send('Erro ao gerar relatório.');
+    }
+});
+
 app.get('/dashboard', async (req, res) => {
     const [items] = await pool.query('SELECT * FROM items');
     const [orders] = await pool.query(

--- a/index.test.js
+++ b/index.test.js
@@ -177,6 +177,27 @@ describe('POST /orders/:id/advance (Kanban - Issue #07)', () => {
     });
 });
 
+describe('GET /admin/export (CSV - Issue #08)', () => {
+    it('should return CSV with correct headers and content', async () => {
+        mockQuery.mockResolvedValueOnce([[
+            { id: 1, customer_name: 'João', item_name: 'Marmita Fitness', total: 22.9, status: 'Aberto', created_at: '2026-06-05T12:00:00Z' }
+        ]]);
+        const res = await request(app).get('/admin/export');
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toMatch(/text\/csv/);
+        expect(res.headers['content-disposition']).toMatch(/attachment; filename="relatorio-vendas.csv"/);
+        expect(res.text).toContain('ID,Cliente,Marmita,Valor,Status,Data');
+        expect(res.text).toContain('"João"');
+        expect(res.text).toContain('22.90');
+    });
+
+    it('should return 500 on database error', async () => {
+        mockQuery.mockRejectedValueOnce(new Error('DB error'));
+        const res = await request(app).get('/admin/export');
+        expect(res.status).toBe(500);
+    });
+});
+
 describe('GET /dashboard', () => {
     it('should render dashboard with items and orders', async () => {
         mockQuery

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -17,10 +17,13 @@
         .kanban-card .meta { font-size: 13px; color: #555; margin: 5px 0; }
         .btn-advance { background: #e94560; color: #fff; border: none; padding: 6px 10px; border-radius: 5px; cursor: pointer; width: 100%; }
         .btn-advance:hover { background: #c81e3c; }
+        .btn-export { display: inline-block; margin: 5px 0 20px; padding: 10px 16px; background: #27ae60; color: #fff; text-decoration: none; border-radius: 6px; font-weight: bold; }
+        .btn-export:hover { background: #1e8449; }
     </style>
 </head>
 <body>
     <h1>Painel Administrativo - MarmitaTech</h1>
+    <a href="/admin/export" class="btn-export">⬇️ Baixar Relatório (CSV)</a>
     <div class="grid">
         <div class="card">
             <h3>Nova Marmita</h3>


### PR DESCRIPTION
## Issue #8 — Relatório de Vendas (Exportação CSV)

### O que foi feito
- ✅ Rota `GET /admin/export` gera `.csv` da tabela `orders`
- ✅ Colunas: **ID, Cliente, Marmita, Valor, Status, Data**
- ✅ Headers corretos (`text/csv` + `Content-Disposition: attachment`)
- ✅ BOM UTF-8 → acentos corretos no Excel; aspas escapadas (RFC 4180)
- ✅ Botão **"Baixar Relatório (CSV)"** no dashboard
- ✅ 2 testes novos (19 no total, verdes)

### Critério de aceite
> O arquivo abre corretamente no Excel com data e valor dos pedidos ✅

Closes #8