### PR TITLE
ci: deploy atrás de feature flag (seguro por padrão)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,13 @@ jobs:
   deploy:
     name: Deploy na EC2 (SSH/SCP)
     needs: [release_docker, trivy_sonar]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main')
+    # SEGURO POR PADRÃO: o deploy só roda se o feature flag estiver explicitamente ligado.
+    # Para ativar o deploy ao vivo: defina a variável de repositório ENABLE_EC2_DEPLOY=true
+    # (Settings > Secrets and variables > Actions > Variables) + os secrets EC2_HOST/EC2_USER.
+    if: >
+      vars.ENABLE_EC2_DEPLOY == 'true' &&
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Job de deploy só roda com a variável ENABLE_EC2_DEPLOY=true. Sem ela, o pipeline faz apenas CI + Release Docker Hub + Trivy. Ativação do deploy fica sob controle humano.