### PR TITLE
ci: docker_build independente do Sonar (gate confiável)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
   # ==========================================================================
   docker_build:
     name: Validação de Build Docker
-    needs: test_sonar
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
   # ==========================================================================
   release_docker:
     name: Release - Build & Push Docker Hub
-    needs: docker_build
+    needs: [test_sonar, docker_build]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
docker_build passa a depender de lint (não do Sonar), permitindo usá-lo como required status check confiável na branch protection da main. Refs #2 #4